### PR TITLE
Adding logging to debug webhook issues

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9226,14 +9226,17 @@ async function run() {
         updateLabels(client, prNumber, newLabels, pullRequestState.labels).then(r => {})
         
         if (pullRequestState.qaStatus === QAStatus.IN_QA) {
+            console.log("Transitioning ticket to In QA status");
             sendMessage(JIRA_IN_QA_WEBHOOK)
         }
         
-        if (pullRequestState.qaStatus === QAStatus.QA_PASSED) {
+        if (pullRequestState.qaStatus === QAStatus.QA_PASSED && !pullRequestState.merged) {
+            console.log("Transitioning ticket to QA Passed status");
             sendMessage(JIRA_QA_PASSED_WEBHOOK)
         }
 
         if (pullRequestState.merged) {
+            console.log("Transitioning ticket to Merged status");
             sendMessage(JIRA_PR_MERGED_WEBHOOK)
         }
 
@@ -9330,10 +9333,12 @@ async function updateLabels(client, prNumber, newLabels, currentLabels) {
 
 
     if (labelsToAdd.includes(Label.READY_FOR_REVIEW.name)) {
+        console.log("Transitioning ticket to Review status");
         sendMessage(JIRA_READY_FOR_REVIEW)
     }
 
     if (labelsToAdd.includes(Label.READY_FOR_QA.name)) {
+        console.log("Transitioning ticket to Ready for QA status");
         sendMessage(JIRA_PR_APPROVED_WEBHOOK)
     }
 

--- a/src/autolabel.js
+++ b/src/autolabel.js
@@ -31,14 +31,17 @@ export async function run() {
         updateLabels(client, prNumber, newLabels, pullRequestState.labels).then(r => {})
         
         if (pullRequestState.qaStatus === QAStatus.IN_QA) {
+            console.log("Transitioning ticket to In QA status");
             sendMessage(JIRA_IN_QA_WEBHOOK)
         }
         
-        if (pullRequestState.qaStatus === QAStatus.QA_PASSED) {
+        if (pullRequestState.qaStatus === QAStatus.QA_PASSED && !pullRequestState.merged) {
+            console.log("Transitioning ticket to QA Passed status");
             sendMessage(JIRA_QA_PASSED_WEBHOOK)
         }
 
         if (pullRequestState.merged) {
+            console.log("Transitioning ticket to Merged status");
             sendMessage(JIRA_PR_MERGED_WEBHOOK)
         }
 
@@ -135,10 +138,12 @@ async function updateLabels(client, prNumber, newLabels, currentLabels) {
 
 
     if (labelsToAdd.includes(Label.READY_FOR_REVIEW.name)) {
+        console.log("Transitioning ticket to Review status");
         sendMessage(JIRA_READY_FOR_REVIEW)
     }
 
     if (labelsToAdd.includes(Label.READY_FOR_QA.name)) {
+        console.log("Transitioning ticket to Ready for QA status");
         sendMessage(JIRA_PR_APPROVED_WEBHOOK)
     }
 

--- a/src/autolabel.js
+++ b/src/autolabel.js
@@ -1,6 +1,6 @@
-import {Label} from "./model/Label";
-import {ApprovalStatus} from "./model/ApprovalStatus";
-import {QAStatus} from "./model/QAStatus.js";
+import { Label } from "./model/Label";
+import { ApprovalStatus } from "./model/ApprovalStatus";
+import { QAStatus } from "./model/QAStatus.js";
 
 const core = require('@actions/core');
 const github = require('@actions/github');
@@ -27,23 +27,11 @@ export async function run() {
         const newLabels = getNewLabels(pullRequestState).map(label => label.name)
 
         console.log(`Updating labels to [${newLabels}]`)
-
-        updateLabels(client, prNumber, newLabels, pullRequestState.labels).then(r => {})
         
-        if (pullRequestState.qaStatus === QAStatus.IN_QA) {
-            console.log("Transitioning ticket to In QA status");
-            sendMessage(JIRA_IN_QA_WEBHOOK)
+        if (github.event.action != 'labeled') {
+            updateLabels(client, prNumber, newLabels, pullRequestState.labels).then(r => { })
         }
-        
-        if (pullRequestState.qaStatus === QAStatus.QA_PASSED && !pullRequestState.merged) {
-            console.log("Transitioning ticket to QA Passed status");
-            sendMessage(JIRA_QA_PASSED_WEBHOOK)
-        }
-
-        if (pullRequestState.merged) {
-            console.log("Transitioning ticket to Merged status");
-            sendMessage(JIRA_PR_MERGED_WEBHOOK)
-        }
+        updateJiraTicket(newLabels, pullRequestState)
 
     } catch (error) {
         core.setFailed(error.message);
@@ -58,14 +46,14 @@ function getPrNumber() {
 
 async function getApprovalStatus(client, prNumber) {
     const { data: reviews } = await client.rest.pulls.listReviews({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            pull_number: prNumber,
-        }
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        pull_number: prNumber,
+    }
     )
 
-    let approvals = reviews.filter( review => review.state === ApprovalStatus.APPROVED.name )
-    let changeRequests = reviews.filter( review => review.state === ApprovalStatus.CHANGES_REQUESTED.name )
+    let approvals = reviews.filter(review => review.state === ApprovalStatus.APPROVED.name)
+    let changeRequests = reviews.filter(review => review.state === ApprovalStatus.CHANGES_REQUESTED.name)
 
     let activeChangeRequests = changeRequests.filter(review => {
         let author = review.user.id
@@ -132,20 +120,9 @@ function getNewLabels(pullRequestState) {
 async function updateLabels(client, prNumber, newLabels, currentLabels) {
     console.log(`Current labels: ${currentLabels}`)
     let labelsToAdd = newLabels.filter(label => !currentLabels.includes(label))
-    let labelsToRemove = Label.allCases().filter(label =>  {
+    let labelsToRemove = Label.allCases().filter(label => {
         return currentLabels.includes(label.name) && !(newLabels.includes(label.name))
     })
-
-
-    if (labelsToAdd.includes(Label.READY_FOR_REVIEW.name)) {
-        console.log("Transitioning ticket to Review status");
-        sendMessage(JIRA_READY_FOR_REVIEW)
-    }
-
-    if (labelsToAdd.includes(Label.READY_FOR_QA.name)) {
-        console.log("Transitioning ticket to Ready for QA status");
-        sendMessage(JIRA_PR_APPROVED_WEBHOOK)
-    }
 
     await Promise.all(
         [addLabels(client, prNumber, labelsToAdd), removeLabels(client, prNumber, labelsToRemove)]
@@ -180,21 +157,49 @@ async function removeLabels(client, prNumber, labels) {
     )
 }
 
+function updateJiraTicket(newLabels, pullRequestState) {
+
+    switch (true) {
+        case pullRequestState.merged:
+            console.log("Transitioning ticket to Merged status");
+            sendMessage(JIRA_PR_MERGED_WEBHOOK)
+            return
+        case pullRequestState.qaStatus === QAStatus.QA_PASSED && !pullRequestState.merged:
+            console.log("Transitioning ticket to QA Passed status");
+            sendMessage(JIRA_QA_PASSED_WEBHOOK)
+            return
+        case pullRequestState.qaStatus === QAStatus.IN_QA:
+            console.log("Transitioning ticket to In QA status");
+            sendMessage(JIRA_IN_QA_WEBHOOK)
+            return
+        case newLabels.includes(Label.READY_FOR_QA.name):
+            console.log("Transitioning ticket to Ready for QA status");
+            sendMessage(JIRA_PR_APPROVED_WEBHOOK)
+            return
+        case newLabels.includes(Label.READY_FOR_REVIEW.name):
+            console.log("Transitioning ticket to Review status");
+            sendMessage(JIRA_READY_FOR_REVIEW)
+            return
+        default:
+            return
+    }
+}
+
 function sendMessage(webhook, requestType = "POST") {
-      const pullRequest = github.context.payload.pull_request
-      if (!pullRequest) { return undefined; }
+    const pullRequest = github.context.payload.pull_request
+    if (!pullRequest) { return undefined; }
 
-      let request = new XMLHttpRequest();
-      request.open(requestType, webhook);
+    let request = new XMLHttpRequest();
+    request.open(requestType, webhook);
 
-      request.setRequestHeader('Content-type', 'application/json');
+    request.setRequestHeader('Content-type', 'application/json');
 
-      let body = {
+    let body = {
         "pr_content": pullRequest.body,
         "pr_title": pullRequest.title,
         "branch_name": pullRequest.head.ref
-      }
+    }
 
-      console.log(`Sending message ${body}`)
-      return request.send(JSON.stringify(body));
+    console.log(`Sending message ${body}`)
+    return request.send(JSON.stringify(body));
 }


### PR DESCRIPTION
Webhooks don't seem to be firing in order, so I'm adding logging to see what is running through each transition


Edit:
Second commit will require `labeled` type under `pull_request_target` for each repo to ensure these events are firing for labels added, and the conditional in `run()` should prevent the update functionality from being run unnecessarily