### PR TITLE
Fixing issues 14 and 15

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,13 @@ inputs:
   WH_DESIGN_REVIEW:
     required: true
     description: 'Webhook for Needs Design Review JIRA actions' 
+  REQUIRED_APPROVALS:
+    required: false
+    description: '(Int) Number of approvals required before code review is considered complete. Default is 1.' 
+  MANUAL_QA_REQUEST:
+    required: false
+    description: '(Bool) Toggle whether the "Ready for QA" label will be automatically applied. If this is true, it will not be auto-added. Default is false' 
+
 
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -9210,6 +9210,13 @@ let JIRA_QA_PASSED_WEBHOOK = core.getInput('WH_QA_PASSED')
 let JIRA_PR_MERGED_WEBHOOK = core.getInput('WH_PR_MERGED')
 let JIRA_DESIGN_REVIEW_WEBHOOK = core.getInput('WH_DESIGN_REVIEW')
 
+// Get required approvals input argument
+const requiredApprovals = parseInt(core.getInput('REQUIRED_APPROVALS')) || 1;
+
+// Get manual QA label input argument
+const manualQARequest = core.getInput('MANUAL_QA_REQUEST') === 'true';
+
+
 async function run() {
     try {
         const token = core.getInput("repo-token", { required: true });
@@ -9263,8 +9270,8 @@ async function getApprovalStatus(client, prNumber) {
             .length === 0
     })
 
-    let approved = approvals.length > 0
-    let changesRequested = activeChangeRequests.length > 0
+    let approved = approvals.length >= requiredApprovals;
+    let changesRequested = activeChangeRequests.length > 0;
 
     if (approved && !changesRequested) {
         return ApprovalStatus.APPROVED
@@ -9299,19 +9306,28 @@ function getNewLabels(pullRequestState) {
     const str = JSON.stringify(pullRequestState, null, 2)
     console.log(`pull request state: ${str}`)
 
+    const hasChangesRequested = pullRequestState.labels.includes(Label.CHANGES_REQUESTED.name);
+    const hasNeedsDesignReview = pullRequestState.labels.includes(Label.NEEDS_DESIGN_REVIEW.name);
+
     switch (true) {
         case !pullRequestState.open && !pullRequestState.merged:
             return []
         case pullRequestState.draft:
             return [Label.WORK_IN_PROGRESS]
-        case pullRequestState.reviewStatus === ApprovalStatus.CHANGES_REQUESTED:
-            return [Label.CHANGES_REQUESTED]
-        case pullRequestState.reviewStatus === ApprovalStatus.NEEDS_REVIEW:
-            return [Label.READY_FOR_REVIEW]
+        case pullRequestState.reviewStatus === ApprovalStatus.CHANGES_REQUESTED && !hasChangesRequested:
+            return [Label.CHANGES_REQUESTED];
+        case pullRequestState.reviewStatus === ApprovalStatus.NEEDS_REVIEW && !hasChangesRequested:
+            return hasNeedsDesignReview ? [Label.READY_FOR_REVIEW, Label.NEEDS_DESIGN_REVIEW.name] : [Label.READY_FOR_REVIEW];
         case pullRequestState.reviewStatus === ApprovalStatus.APPROVED:
-            return [Label.REVIEW_PASSED, pullRequestState.qaStatus.label()]
+            if (manualQA) {
+                // If manual QA is enabled, keep the existing QA status label
+                return [Label.REVIEW_PASSED, pullRequestState.qaStatus.label()];
+            } else {
+                // If manual QA is disabled, automatically set the "Ready for QA" label
+                return [Label.REVIEW_PASSED, Label.READY_FOR_QA];
+            }
         default:
-            return []
+            return hasNeedsDesignReview ? [Label.NEEDS_DESIGN_REVIEW.name] : [];
     }
 }
 
@@ -9345,13 +9361,15 @@ async function removeLabels(client, prNumber, labels) {
 
     console.log(`Removing labels: ${labels.map(label => label.name)}`)
 
-    labels.map((label) =>
-        client.rest.issues.removeLabel({
-            owner: github.context.repo.owner,
-            repo: github.context.repo.repo,
-            issue_number: prNumber,
-            name: label.name,
-        })
+    await Promise.all(
+        labels.map((label) =>
+            client.rest.issues.removeLabel({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: prNumber,
+                name: label.name,
+            })
+        )
     )
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9137,7 +9137,6 @@ class Label {
         return [
             this.READY_FOR_REVIEW,
             this.REVIEW_PASSED,
-            this.CHANGES_REQUESTED,
             this.READY_FOR_QA,
             this.WORK_IN_PROGRESS,
             this.IN_QA,
@@ -9250,43 +9249,24 @@ function getPrNumber() {
 }
 
 async function getApprovalStatus(client, prNumber) {
-  const { data: reviews } = await client.rest.pulls.listReviews({
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    pull_number: prNumber,
-  }
-  )
-
-  let approvals = reviews.filter((review) => review.state === ApprovalStatus.APPROVED.name)
-  let changeRequests = reviews.filter((review) => review.state === ApprovalStatus.CHANGES_REQUESTED.name)
-
-  let activeChangeRequests = changeRequests.filter((review) => {
-    let author = review.user.id
-    let submittedAt = review.submitted_at
-
-    // Check for re-requests from the same user
-    let reRequests = changeRequests.filter((req) => {
-      return req.user.id === author && req.submitted_at > submittedAt
+    const { data: reviews } = await client.rest.pulls.listReviews({
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        pull_number: prNumber,
     })
 
-    // Ignore previous change requests from the user who requested changes
-    return (
-      approvals.filter((review) => review.user.id === author && review.submitted_at > submittedAt).length === 0 &&
-      reRequests.length === 0
-    )
-  })
+    let approvals = reviews.filter(review => review.state === ApprovalStatus.APPROVED.name)
 
-  let approved = approvals.length >= requiredApprovals
-  let changesRequested = activeChangeRequests.length > 0
+    let approved = approvals.length >= requiredApprovals
 
-  if (approved && !changesRequested) {
-    return ApprovalStatus.APPROVED
-  } else if (changesRequested) {
-    return ApprovalStatus.CHANGES_REQUESTED
-  } else {
-    return ApprovalStatus.NEEDS_REVIEW
-  }
+    if (approved) {
+        return ApprovalStatus.APPROVED
+    } else {
+        return ApprovalStatus.NEEDS_REVIEW
+    }
 }
+
+// w
 
 async function getPullRequestState(client, prNumber) {
     const approvalStatus = await getApprovalStatus(client, prNumber)
@@ -9312,7 +9292,6 @@ function getNewLabels(pullRequestState) {
     const str = JSON.stringify(pullRequestState, null, 2)
     console.log(`pull request state: ${str}`)
 
-    const hasChangesRequested = pullRequestState.labels.includes(Label.CHANGES_REQUESTED.name);
     const hasNeedsDesignReview = pullRequestState.labels.includes(Label.NEEDS_DESIGN_REVIEW.name);
 
     switch (true) {
@@ -9320,14 +9299,12 @@ function getNewLabels(pullRequestState) {
             return []
         case pullRequestState.draft:
             return [Label.WORK_IN_PROGRESS]
-        case pullRequestState.reviewStatus === ApprovalStatus.CHANGES_REQUESTED && !hasChangesRequested:
-            return [Label.CHANGES_REQUESTED];
-        case pullRequestState.reviewStatus === ApprovalStatus.NEEDS_REVIEW && !hasChangesRequested:
+        case pullRequestState.reviewStatus === ApprovalStatus.NEEDS_REVIEW:
             return hasNeedsDesignReview ? [Label.READY_FOR_REVIEW, Label.NEEDS_DESIGN_REVIEW.name] : [Label.READY_FOR_REVIEW];
         case pullRequestState.reviewStatus === ApprovalStatus.APPROVED:
-            if (manualQA) {
-                // If manual QA is enabled, keep the existing QA status label
-                return [Label.REVIEW_PASSED, pullRequestState.qaStatus.label()];
+            if (manualQARequest) {
+                // If manual QA is enabled, only apply the "Review Passed" label
+                return [Label.REVIEW_PASSED];
             } else {
                 // If manual QA is disabled, automatically set the "Ready for QA" label
                 return [Label.REVIEW_PASSED, Label.READY_FOR_QA];

--- a/src/autolabel.js
+++ b/src/autolabel.js
@@ -53,36 +53,42 @@ function getPrNumber() {
 }
 
 async function getApprovalStatus(client, prNumber) {
-    const { data: reviews } = await client.rest.pulls.listReviews({
-        owner: github.context.repo.owner,
-        repo: github.context.repo.repo,
-        pull_number: prNumber,
-    }
-    )
+  const { data: reviews } = await client.rest.pulls.listReviews({
+    owner: github.context.repo.owner,
+    repo: github.context.repo.repo,
+    pull_number: prNumber,
+  }
+  )
 
-    let approvals = reviews.filter(review => review.state === ApprovalStatus.APPROVED.name)
-    let changeRequests = reviews.filter(review => review.state === ApprovalStatus.CHANGES_REQUESTED.name)
+  let approvals = reviews.filter((review) => review.state === ApprovalStatus.APPROVED.name)
+  let changeRequests = reviews.filter((review) => review.state === ApprovalStatus.CHANGES_REQUESTED.name)
 
-    let activeChangeRequests = changeRequests.filter(review => {
-        let author = review.user.id
-        let submittedAt = review.submitted_at
+  let activeChangeRequests = changeRequests.filter((review) => {
+    let author = review.user.id
+    let submittedAt = review.submitted_at
 
-        return approvals
-            .filter(review => { return review.user.id === author })
-            .filter(review => { return review.submitted_at > submittedAt })
-            .length === 0
+    // Check for re-requests from the same user
+    let reRequests = changeRequests.filter((req) => {
+      return req.user.id === author && req.submitted_at > submittedAt
     })
 
-    let approved = approvals.length >= requiredApprovals;
-    let changesRequested = activeChangeRequests.length > 0;
+    // Ignore previous change requests from the user who requested changes
+    return (
+      approvals.filter((review) => review.user.id === author && review.submitted_at > submittedAt).length === 0 &&
+      reRequests.length === 0
+    )
+  })
 
-    if (approved && !changesRequested) {
-        return ApprovalStatus.APPROVED
-    } else if (changesRequested) {
-        return ApprovalStatus.CHANGES_REQUESTED
-    } else {
-        return ApprovalStatus.NEEDS_REVIEW
-    }
+  let approved = approvals.length >= requiredApprovals
+  let changesRequested = activeChangeRequests.length > 0
+
+  if (approved && !changesRequested) {
+    return ApprovalStatus.APPROVED
+  } else if (changesRequested) {
+    return ApprovalStatus.CHANGES_REQUESTED
+  } else {
+    return ApprovalStatus.NEEDS_REVIEW
+  }
 }
 
 async function getPullRequestState(client, prNumber) {

--- a/src/model/Label.js
+++ b/src/model/Label.js
@@ -16,7 +16,6 @@ export class Label {
         return [
             this.READY_FOR_REVIEW,
             this.REVIEW_PASSED,
-            this.CHANGES_REQUESTED,
             this.READY_FOR_QA,
             this.WORK_IN_PROGRESS,
             this.IN_QA,


### PR DESCRIPTION
Issue #15 should be handled in this PR

Once the pull request has the specified number of approvals (controlled by the REQUIRED_APPROVALS input), it will be considered ready for QA. If the MANUAL_QA_REQUEST input is set to true, the "Ready for QA" label must be added manually; otherwise, it will be added automatically.

At any point, the "Needs Design Review" label can be added manually, and it will remain on the pull request until it is removed manually by a designer after their review/approval.

This will not break the actions for the repos currently using it