### PR TITLE
Fixing bug with auto-re-applying ready for QA label

### DIFF
--- a/src/autolabel.js
+++ b/src/autolabel.js
@@ -97,6 +97,7 @@ function getNewLabels(pullRequestState) {
     console.log(`pull request state: ${str}`)
 
     const hasNeedsDesignReview = pullRequestState.labels.includes(Label.NEEDS_DESIGN_REVIEW.name);
+    const currentQAStatus = QAStatus.fromLabels(pullRequestState.labels);
 
     switch (true) {
         case !pullRequestState.open && !pullRequestState.merged:
@@ -111,7 +112,7 @@ function getNewLabels(pullRequestState) {
                 return [Label.REVIEW_PASSED];
             } else {
                 // If manual QA is disabled, automatically set the "Ready for QA" label
-                return [Label.REVIEW_PASSED, Label.READY_FOR_QA];
+                return [Label.REVIEW_PASSED, pullRequestState.qaStatus.label()];
             }
         default:
             return hasNeedsDesignReview ? [Label.NEEDS_DESIGN_REVIEW.name] : [];
@@ -122,13 +123,14 @@ async function updateLabels(client, prNumber, newLabels, currentLabels) {
     console.log(`Current labels: ${currentLabels}`)
     let labelsToAdd = newLabels.filter(label => !currentLabels.includes(label))
     let labelsToRemove = Label.allCases().filter(label => {
-        return currentLabels.includes(label.name) && !(newLabels.includes(label.name))
+        return currentLabels.includes(label.name) && !(newLabels.includes(label.name)) && label.name !== Label.IN_QA.name && label.name !== Label.QA_PASSED.name && label.name !== Label.QA_FAILED.name;
     })
 
     await Promise.all(
         [addLabels(client, prNumber, labelsToAdd), removeLabels(client, prNumber, labelsToRemove)]
     )
 }
+
 
 async function addLabels(client, prNumber, labels) {
     if (labels.length <= 0) { return }

--- a/src/model/Label.js
+++ b/src/model/Label.js
@@ -6,6 +6,7 @@ export class Label {
     static READY_FOR_QA = new Label("Ready for QA")
     static IN_QA = new Label("In QA")
     static QA_PASSED = new Label("QA passed")
+    static QA_FAILED = new Label("QA failed")
     static NEEDS_DESIGN_REVIEW = new Label("Needs Design Review")
 
     constructor(name) {
@@ -20,6 +21,7 @@ export class Label {
             this.WORK_IN_PROGRESS,
             this.IN_QA,
             this.QA_PASSED,
+            this.QA_FAILED,
             this.NEEDS_DESIGN_REVIEW
         ]
     }

--- a/src/model/QAStatus.js
+++ b/src/model/QAStatus.js
@@ -4,6 +4,8 @@ export class QAStatus {
     static NEEDS_QA = new QAStatus("NEEDS_QA")
     static IN_QA = new QAStatus("IN_QA")
     static QA_PASSED = new QAStatus("QA_PASSED")
+    static QA_FAILED = new QAStatus("QA_FAILED")
+
 
     constructor(name) {
         this.name = name
@@ -17,6 +19,8 @@ export class QAStatus {
                 return Label.IN_QA
             case QAStatus.QA_PASSED:
                 return Label.QA_PASSED
+            case QAStatus.QA_FAILED:
+                return Label.QA_FAILED
         }
     }
 
@@ -26,10 +30,10 @@ export class QAStatus {
                 return QAStatus.IN_QA
             case labels.includes(Label.QA_PASSED.name):
                 return QAStatus.QA_PASSED
+            case labels.includes(Label.QA_FAILED.name):
+                return QAStatus.QA_FAILED
             default:
                 return QAStatus.NEEDS_QA
         }
     }
-
-
 }


### PR DESCRIPTION
I think this fixes the issue where the "Ready for QA" label being removed triggers the workflow to re-add it